### PR TITLE
"on duplicate update +=" and "rows_per_query"

### DIFF
--- a/lib/fluent/plugin/out_mysql_bulk.rb
+++ b/lib/fluent/plugin/out_mysql_bulk.rb
@@ -116,8 +116,6 @@ module Fluent
         
       end
       
-      log.warn @rows_per_query
-      
 
       if rows != 0
           sql = "INSERT INTO #{@table} (#{@column_names.join(',')}) VALUES #{values_templates.join(',')}"


### PR DESCRIPTION
1. Appended a possibility of building quesies like 
   INSERT ...
   ON DUPLICATE ON DUPLICATE KEY UPDATE column1 += VALUES(column1)

For use this feature you should specify the next line in your config:
on_duplicate_update_keys +=column1
1. New parameter rows_per_query specifies maximum number of rows for one insert. It helps to split very big chunks.
   Example:
   rows_per_query 5000.
   If input chunk has 19000 rows to insert, then we will get 4 insert queries with not more than 5000 rows.
