### PR TITLE
Support secret parameters featrue

### DIFF
--- a/lib/fluent/plugin/out_mysql_bulk.rb
+++ b/lib/fluent/plugin/out_mysql_bulk.rb
@@ -7,7 +7,7 @@ module Fluent
     config_param :port, :integer, default: 3306
     config_param :database, :string
     config_param :username, :string
-    config_param :password, :string, default: ''
+    config_param :password, :string, default: '', secret: true
 
     config_param :column_names, :string
     config_param :key_names, :string, default: nil


### PR DESCRIPTION
Fluentd 0.12.13 or later supports secret parameter feature.
This feature works as below:

```log
  <match mysql.input>
    type mysql_bulk
    host localhost
    database test_app_development
    username root
    password xxxxxx
    column_names id,user_name,created_at,updated_at
    table users
    flush_interval 10s
  </match>
</ROOT>
```