### PR TITLE
Added json_key_names property in order to store values as json string.

### DIFF
--- a/lib/fluent/plugin/out_mysql_bulk.rb
+++ b/lib/fluent/plugin/out_mysql_bulk.rb
@@ -11,6 +11,7 @@ module Fluent
 
     config_param :column_names, :string
     config_param :key_names, :string, default: nil
+    config_param :json_key_names, :string, default: nil
     config_param :table, :string
 
     config_param :on_duplicate_key_update, :bool, default: false
@@ -46,6 +47,7 @@ module Fluent
 
       @column_names = @column_names.split(',')
       @key_names = @key_names.nil? ? @column_names : @key_names.split(',')
+      @json_key_names = @json_key_names.split(',') if @json_key_names
     end
 
     def start
@@ -111,6 +113,10 @@ module Fluent
               value = record[key]
             else
               value = record[key].slice(0, @max_lengths[i])
+            end
+
+            if @json_key_names && @json_key_names.include?(key)
+              value = value.to_json
             end
           end
           values << value

--- a/test/plugin/test_out_mysql_bulk.rb
+++ b/test/plugin/test_out_mysql_bulk.rb
@@ -112,6 +112,18 @@ class MysqlBulkOutputTest < Test::Unit::TestCase
         on_duplicate_update_keys user_name,updated_at
       ]
     end
+
+    assert_nothing_raised(Fluent::ConfigError) do
+      d = create_driver %[
+        database test_app_development
+        username root
+        password hogehoge
+        key_names id,url,request_headers,params,created_at,updated_at
+        column_names id,url,request_headers_json,params_json,created_date,updated_date
+        json_key_names request_headers,params
+        table access
+      ]
+    end
   end
 
   def test_variables
@@ -127,6 +139,7 @@ class MysqlBulkOutputTest < Test::Unit::TestCase
 
     assert_equal ['id','user_name','created_at','updated_at'], d.instance.key_names
     assert_equal ['id','user_name','created_at','updated_at'], d.instance.column_names
+    assert_equal nil, d.instance.json_key_names
     assert_equal " ON DUPLICATE KEY UPDATE user_name = VALUES(user_name),updated_at = VALUES(updated_at)", d.instance.instance_variable_get(:@on_duplicate_key_update_sql)
 
     d = create_driver %[
@@ -139,6 +152,7 @@ class MysqlBulkOutputTest < Test::Unit::TestCase
 
     assert_equal ['id','user_name','created_at','updated_at'], d.instance.key_names
     assert_equal ['id','user_name','created_at','updated_at'], d.instance.column_names
+    assert_equal nil, d.instance.json_key_names
     assert_nil d.instance.instance_variable_get(:@on_duplicate_key_update_sql)
 
     d = create_driver %[
@@ -152,6 +166,22 @@ class MysqlBulkOutputTest < Test::Unit::TestCase
 
     assert_equal ['id','user_name','created_at','updated_at'], d.instance.key_names
     assert_equal ['id','user','created_date','updated_date'], d.instance.column_names
+    assert_equal nil, d.instance.json_key_names
+    assert_nil d.instance.instance_variable_get(:@on_duplicate_key_update_sql)
+
+    d = create_driver %[
+      database test_app_development
+      username root
+      password hogehoge
+      key_names id,url,request_headers,params,created_at,updated_at
+      column_names id,url,request_headers_json,params_json,created_date,updated_date
+      json_key_names request_headers,params
+      table access
+    ]
+
+    assert_equal ['id','url','request_headers','params','created_at','updated_at'], d.instance.key_names
+    assert_equal ['id','url','request_headers_json','params_json','created_date','updated_date'], d.instance.column_names
+    assert_equal ['request_headers','params'], d.instance.json_key_names
     assert_nil d.instance.instance_variable_get(:@on_duplicate_key_update_sql)
   end
 end


### PR DESCRIPTION
I'd like to handle the logs which include nested json such like below.

```
{
  "url": "/",
  "params": {
    "limit": 5,
    "offset": 15
  },
  "request_headers": {
    "Authorization": "Bearer ***"
  },
  "created_at": "2016-02-18 00:00:00"
}
```

```
create table `access` (
  `id` int(10) not null auto_increment,
  `url` varchar(256) not null,
  `remote_ip` varchar(32) not null,
  `params_json` text,
  `request_headers_json` text,
  `created_at` datetime not null,
  primary key (`id`)
)
```

I confirmed the original version can store nested json but they're stored as the ruby hash encoded string because maybe stored as to_s of record[key].
How about adding json_key_names property?
Please give advise.
